### PR TITLE
proper kerning for multi-character dimensions

### DIFF
--- a/cc.sty
+++ b/cc.sty
@@ -28,7 +28,7 @@
 \newcommand{\dimMeta}{D}
 \newcommand{\chcL}{\OB{\langle}}
 \newcommand{\chcR}{\OB{\rangle}}
-\newcommand{\chc}[2][\dimMeta]{\OB{#1\chcL#2\chcR}}
+\newcommand{\chc}[2][\dimMeta]{\OB{\textit{#1}\chcL#2\chcR}}
 \newcommand{\chcPP}[3][\dimMeta]{\chc[#1]{\prog{#2},\prog{#3}}}
 \newcommand{\chcPPP}[4][\dimMeta]{\chc[#1]{\prog{#2},\prog{#3},\prog{#4}}}
 
@@ -85,7 +85,7 @@
 \newcommand{\plain}[1]{\OB{\underline{#1}}}
 
 
-% 
+%
 % design theory
 %
 


### PR DESCRIPTION
Currently if you use a longer dimension name it is not treated as a single word because of how math mode works.  Wrapping it inside \textit{} ensures that it's kerned as a single word.